### PR TITLE
fix: avoid error notification when user cancels screenshot

### DIFF
--- a/src/kasasa-window.c
+++ b/src/kasasa-window.c
@@ -491,8 +491,7 @@ on_screenshot_taken (GObject      *object,
   // If failed to get the URI, set the error message
   if (error != NULL)
     {
-      error_message = g_strconcat (_("Reason: "), error->message, NULL);
-      goto ERROR_NOTIFICATION;
+      goto EXIT_APP;
     }
 
   if (uri == NULL)
@@ -520,6 +519,7 @@ ERROR_NOTIFICATION:
                                    "io.github.kelvinnovais.Kasasa",
                                    notification);
 
+EXIT_APP:
   g_warning ("%s", error->message);
 
   gtk_window_close (GTK_WINDOW (self));


### PR DESCRIPTION
Displaying an error notification when user decides to back out from taking a screenshot is not a proper behavior. The user can cancel the screenshot by either pressing ESC or by clicking on the "x" button.

![image](https://github.com/user-attachments/assets/3f941946-47a1-4ed5-bc25-9f82608fb0b0)

I am not sure if there's any way to actually discover the fact that the user wanted to cancel the screenshot. I just see that the error gets set when the user cancels. I'm not sure what other kinds of errors might occur.