### PR TITLE
updated German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -9,14 +9,14 @@ msgstr ""
 "Project-Id-Version: kasasa\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-05-27 12:35-0300\n"
-"PO-Revision-Date: 2025-05-27 12:14-0300\n"
+"PO-Revision-Date: 2025-05-28 18:49+0200\n"
 "Last-Translator: Uwe Senkler\n"
 "Language-Team: \n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Gtranslator 48.0\n"
+"X-Generator: Poedit 3.6\n"
 
 #: data/io.github.kelvinnovais.Kasasa.desktop.in:2
 #: data/io.github.kelvinnovais.Kasasa.metainfo.xml.in:5
@@ -63,8 +63,8 @@ msgstr "Einem Tastenkürzel"
 #: data/io.github.kelvinnovais.Kasasa.metainfo.xml.in:37
 msgid ""
 "On GNOME, go to Settings → Keyboard → View and Customize Shortcuts → Custom "
-"Shortcuts. There you can set a shortcut to run <code>flatpak run "
-"io.github.kelvinnovais.Kasasa</code> "
+"Shortcuts. There you can set a shortcut to run <code>flatpak run io.github."
+"kelvinnovais.Kasasa</code> "
 msgstr ""
 "In GNOME gehen Sie zu Einstellungen → Tastatur → Tastenkürzel anzeigen und "
 "anpassen → Eigene Tastenkürzel. Dort können Sie ein Tastenkürzel zum "
@@ -167,19 +167,19 @@ msgstr "In die Zwischenablage kopiert"
 
 #: src/kasasa-picture-container.ui:93
 msgid "Add screenshot"
-msgstr "Screenshot hinzufügen"
+msgstr "Bildschirmfoto hinzufügen"
 
 #: src/kasasa-picture-container.ui:102
 msgid "Remove screenshot"
-msgstr "Screenshot entfernen"
+msgstr "Bildschirmfoto entfernen"
 
 #: src/kasasa-picture-container.ui:130
 msgid "Retake screenshot"
-msgstr "Screenshot erneut aufnehmen"
+msgstr "Bildschirmfoto erneut aufnehmen"
 
 #: src/kasasa-picture-container.ui:138
 msgid "Copy screenshot"
-msgstr "Screenshot kopieren"
+msgstr "Bildschirmfoto kopieren"
 
 #: src/kasasa-preferences.ui:12
 msgid "Window hide mode"
@@ -187,7 +187,7 @@ msgstr "Fenster-Ausblendmodus"
 
 #: src/kasasa-preferences.ui:17
 msgid "Decrease opacity"
-msgstr "Opazität verringern"
+msgstr "Deckkraft verringern"
 
 #: src/kasasa-preferences.ui:29
 msgid "Opacity level"


### PR DESCRIPTION
screenshot is Bildschirmfoto in Gnome's German
Opazität is a technical termn mostly used in medical contexts, Deckkraft is much better and understandable by everyone

(it seems that error warnings are not translatable, I happened to see  "Screenshot failed" on a German lanaugae system  when playing around in Kasasa)